### PR TITLE
DROID-1006: [Crashlytics] [Linked Issue] Nullpointer on FixedLayout

### DIFF
--- a/bottom-navigation/src/main/java/it/sephiroth/android/library/bottomnavigation/FixedLayout.kt
+++ b/bottom-navigation/src/main/java/it/sephiroth/android/library/bottomnavigation/FixedLayout.kt
@@ -83,11 +83,12 @@ class FixedLayout(context: Context) : ItemsLayoutContainer(context) {
             return
         }
 
-        val current = getChildAt(oldSelectedIndex) as BottomNavigationFixedItemView
-        val child = getChildAt(index) as BottomNavigationFixedItemView
+        val current = getChildAt(oldSelectedIndex) as BottomNavigationFixedItemView?
+        val child = getChildAt(index) as BottomNavigationFixedItemView?
+        val willAnimate = animate && null != current && null != child
 
-        current.setExpanded(false, 0, animate)
-        child.setExpanded(true, 0, animate)
+        current?.setExpanded(false, 0, animate)
+        child?.setExpanded(true, 0, animate)
     }
 
     override fun setItemEnabled(index: Int, enabled: Boolean) {


### PR DESCRIPTION
https://joinhomebase.atlassian.net/browse/DROID-1006

All ItemsLayoutContainer.setSelectedIndex have this protection. The only container withoutit is the FixedLayout. This commit fixes it. 